### PR TITLE
Add support for Dot Notation (fixes ISS-349)

### DIFF
--- a/Sources/Mustache.swift
+++ b/Sources/Mustache.swift
@@ -195,7 +195,17 @@ public class MustacheEvaluationContext {
 	/// - parameter named: The name of the value to find
 	/// - returns: The value, if found, or nil
 	public func getValue(named nam: String) -> MapType.Value? {
-		let v = mapValues[nam]
+		let values = nam.components(separatedBy: ".")
+		
+		var cntxt: MapType.Value? = mapValues
+		for val in values {
+			guard let prev = cntxt as? MapType else {
+				break
+			}
+			cntxt = prev[val]
+		}
+		
+		let v = cntxt
 		if v == nil && parent != nil {
 			return parent?.getValue(named: nam)
 		}

--- a/Tests/PerfectMustacheTests/PerfectMustacheTests.swift
+++ b/Tests/PerfectMustacheTests/PerfectMustacheTests.swift
@@ -164,6 +164,42 @@ class PerfectMustacheTests: XCTestCase {
 			XCTAssert(false, "\(error)")
 		}
 	}
+	
+	func testDotNotation1() {
+		let usingTemplate = "TOP {\n{{name.first}} {{name.last}}\n}\nBOTTOM"
+		do {
+			let template = try MustacheParser().parse(string: usingTemplate)
+			let d = ["name": ["first": "The", "last": "name"]] as [String:Any]
+			
+			let response = ShimHTTPResponse()
+			
+			let context = MustacheWebEvaluationContext(webResponse: response, map: d)
+			let collector = MustacheEvaluationOutputCollector()
+			template.evaluate(context: context, collector: collector)
+			
+			XCTAssertEqual(collector.asString(), "TOP {\nThe name\n}\nBOTTOM")
+		} catch {
+			XCTAssert(false)
+		}
+	}
+	
+	func testDotNotation2() {
+		let usingTemplate = "TOP {\n{{foo.data.name.first}} {{foo.data.name.last}}\n}\nBOTTOM"
+		do {
+			let template = try MustacheParser().parse(string: usingTemplate)
+			let d = ["foo": ["data": ["name": ["first": "The", "last": "name"]]]] as [String:Any]
+			
+			let response = ShimHTTPResponse()
+			
+			let context = MustacheWebEvaluationContext(webResponse: response, map: d)
+			let collector = MustacheEvaluationOutputCollector()
+			template.evaluate(context: context, collector: collector)
+			
+			XCTAssertEqual(collector.asString(), "TOP {\nThe name\n}\nBOTTOM")
+		} catch {
+			XCTAssert(false)
+		}
+	}
 
     static var allTests : [(String, (PerfectMustacheTests) -> () throws -> Void)] {
 		return [
@@ -171,7 +207,9 @@ class PerfectMustacheTests: XCTestCase {
 			("testMustacheLambda1", testMustacheLambda1),
 			("testMustacheParser2", testMustacheParser2),
 			("testMustacheLambda2", testMustacheLambda2),
-			("testPartials1", testPartials1)
+			("testPartials1", testPartials1),
+			("testDotNotation1", testDotNotation1),
+			("testDotNotation2", testDotNotation2)
         ]
     }
 }


### PR DESCRIPTION
Does as the title says. Please run whatever tests you want to before merging, but everything should continue to work just fine (all unit tests passed).