### PR TITLE
Updated for Swift 3.1

### DIFF
--- a/Sources/Mustache.swift
+++ b/Sources/Mustache.swift
@@ -655,7 +655,7 @@ public class MustacheParser {
 	var handlingUnencodedName = false
 	var testingPutback: String?
 	
-	typealias UGen = String.UnicodeScalarView.Generator
+	typealias UGen = String.UnicodeScalarView.Iterator
 	
 	var g: UGen?
 	var offset = -1


### PR DESCRIPTION
Generator was renamed to Iterator, and thus updated